### PR TITLE
docs: Add github templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -1,0 +1,77 @@
+name: Bug Report
+description: Report a bug to help us fix issues and improve the project.
+title: "[Bug]: "
+labels: ["🐞 BugFix"]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Thanks for taking the time to fill out this bug report!
+
+  - type: textarea
+    id: current-behavior
+    attributes:
+      label: Current Behavior
+      description: Describe what is happening, including any error messages or unexpected behavior.
+      placeholder: Tell us what you see!
+      value: |
+        - Description 1
+        - Description 2
+        - Description 3
+    validations:
+      required: true
+
+  - type: textarea
+    id: expected-behavior
+    attributes:
+      label: Expected Behavior
+      description: Describe what you expected to happen instead.
+      placeholder: Tell us what you expected!
+      value: |
+        - Description 1
+        - Description 2
+        - Description 3
+    validations:
+      required: true
+
+  - type: textarea
+    id: reproduce
+    attributes:
+      label: Steps To Reproduce
+      description: Provide a step-by-step guide to reproduce the issue.
+      placeholder: |
+        1. In this environment...
+        1. With this config...
+        1. Run '...'
+        1. See error...
+    validations:
+      required: true
+
+  - type: textarea
+    id: logs
+    attributes:
+      label: Relevant log output
+      description: Please copy and paste any relevant log output. This will be automatically formatted into code, so no need for backticks.
+      render: shell
+    validations:
+      required: false
+
+  - type: textarea
+    id: additional-context
+    attributes:
+      label: Anything else?
+      description: |
+        Links? References? Anything that will give us more context about the issue you are encountering!
+    validations:
+      required: false
+
+  - type: checkboxes
+    id: issue-confirmation
+    attributes:
+      label: Issue Submission Checklist
+      description: Before submitting, please confirm that the issue template is properly completed.
+      options:
+        - label: I have assigned this issue to myself or the appropriate person.
+          required: true
+        - label: I have added the appropriate labels for this issue.
+          required: true

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,1 @@
+blank_issues_enabled: false

--- a/.github/ISSUE_TEMPLATE/feature_request.yml
+++ b/.github/ISSUE_TEMPLATE/feature_request.yml
@@ -1,0 +1,55 @@
+name: Feature Request
+description: Suggest a new feature, UI improvement, or documentation enhancement.
+title: "[Feat]: "
+labels: ["✨ Feature"]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Thanks for taking the time to submit a feature request!  
+        Please provide as much detail as possible to help us understand your suggestion.
+
+  - type: textarea
+    id: description
+    attributes:
+      label: Feature Description
+      description: Describe the feature in detail. What problem does it solve? How will it improve the project?
+      placeholder: Explain the feature clearly.
+      value: |
+        - Description 1
+        - Description 2
+        - Description 3
+    validations:
+      required: true
+
+  - type: textarea
+    id: todos
+    attributes:
+      label: Implementation Steps (TODO)
+      description: Outline the steps required to implement this feature.
+      value: |
+        - [ ] TODO 1
+        - [ ] TODO 2
+        - [ ] TODO 3
+    validations:
+      required: true
+
+  - type: textarea
+    id: additional-context
+    attributes:
+      label: Additional Context & References
+      description: Provide any additional information, links, or references related to this feature request.
+      placeholder: Include related discussions, documentation links, or any useful resources.
+    validations:
+      required: false
+
+  - type: checkboxes
+    id: feature-confirmation
+    attributes:
+      label: Feature Request Checklist
+      description: Please confirm that you have properly filled out this feature request template.
+      options:
+        - label: I have assigned this issue to myself or the appropriate person.
+          required: true
+        - label: I have added the appropriate labels for this issue.
+          required: true

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,37 @@
+### Related Issues
+
+---
+
+> Please specify the related issue number(s), e.g., #1
+
+<br><br>
+
+### Description
+
+---
+
+> Briefly describe the changes made in this PR.
+
+<br><br>
+
+### Checklist
+
+---
+
+- [ ] Have you tested it in the local environment?
+- [ ] Have you cleaned up unnecessary code? (comments, print statements, etc.)
+- [ ] Have you used commit messages following the convention?
+
+<br><br>
+
+### Screenshots (Optional)
+
+---
+
+<br><br>
+
+### Additional Context (Optional)
+
+---
+
+<br><br>


### PR DESCRIPTION
This PR adds GitHub Issue and PR templates including:

- Issue template config
- Feature request template
- Bug report template
- Pull request template

---

This PR was generated by [jhssong/github-template](https://github.com/jhssong/github-template).