### PR TITLE
fix: Fix global exception handler working properly

### DIFF
--- a/src/config/database.py
+++ b/src/config/database.py
@@ -3,7 +3,7 @@ from sqlalchemy import create_engine
 from sqlalchemy.orm import sessionmaker
 from sqlalchemy.exc import SQLAlchemyError
 from src.config.config import DATABASE_URL
-from src.config.logger_config import setup_logger, add_daily_file_handler
+from src.config.logger_config import setup_logger
 from src.exceptions.definitions import SQLError
 
 engine = create_engine(DATABASE_URL, echo=False)
@@ -12,7 +12,6 @@ session = sessionmaker(bind=engine)
 Base = declarative_base()
 
 logger = setup_logger(__name__)
-add_daily_file_handler(logger)
 
 
 def initialize_database():

--- a/src/config/middleware.py
+++ b/src/config/middleware.py
@@ -1,6 +1,17 @@
+from datetime import datetime
+from fastapi.responses import JSONResponse
 from starlette.requests import Request
 from src.auth.util.jwt import parse_token
-from src.exceptions.definitions import InvalidJwtToken, JwtTokenNotFound
+from src.exceptions.definitions import (
+    BaseAppException,
+    InvalidJwtToken,
+    JwtTokenNotFound,
+)
+from src.exceptions.schemas import ErrorResponse
+from src.config.logger_config import setup_logger, add_daily_file_handler
+
+logger = setup_logger(__name__)
+add_daily_file_handler(logger)
 
 
 async def jwt_authentication_middleware(request: Request, call_next):
@@ -14,18 +25,26 @@ async def jwt_authentication_middleware(request: Request, call_next):
     if any(request.url.path.startswith(path) for path in allow_paths):
         return await call_next(request)
 
-    # Extract Authorization header
-    auth_header = request.headers.get("Authorization")
-    if not auth_header or not auth_header.startswith("Bearer "):
-        raise JwtTokenNotFound()
-
-    access_token = auth_header[7:]  # Remove 'Bearer '
-
     try:
-        user_id = parse_token(access_token)
-        request.state.user_id = user_id
-    except ValueError:
-        raise InvalidJwtToken()
+        # Extract Authorization header
+        auth_header = request.headers.get("Authorization")
+        if not auth_header or not auth_header.startswith("Bearer "):
+            raise JwtTokenNotFound()
 
-    response = await call_next(request)
-    return response
+        access_token = auth_header[7:]  # Remove 'Bearer '
+
+        try:
+            user_id = parse_token(access_token)
+            request.state.user_id = user_id
+        except ValueError:
+            raise InvalidJwtToken()
+
+        response = await call_next(request)
+        return response
+    except BaseAppException as exc:
+        now = datetime.now().isoformat()
+        logger.error(f"{exc.status_code} - {exc.message}")
+        return JSONResponse(
+            status_code=exc.status_code,
+            content=ErrorResponse(message=exc.message, timestamp=now).model_dump(),
+        )

--- a/src/exceptions/handler.py
+++ b/src/exceptions/handler.py
@@ -14,7 +14,7 @@ async def base_app_exception_handler(
     request: Request, exc: BaseAppException
 ) -> JSONResponse:
     now = datetime.now().isoformat()
-    logger.warning(f"{exc.status_code} - {exc.message}")
+    logger.error(f"{exc.status_code} - {exc.message}")
     return JSONResponse(
         status_code=exc.status_code,
         content=ErrorResponse(message=exc.message, timestamp=now).model_dump(),

--- a/src/main.py
+++ b/src/main.py
@@ -2,7 +2,7 @@ from fastapi import FastAPI
 from fastapi.middleware.cors import CORSMiddleware
 
 from src.config.middleware import jwt_authentication_middleware
-from src.exceptions.definitions import BaseAppException, InvalidJsonDataFormat
+from src.exceptions.definitions import BaseAppException
 import src.models  # noqa: F401
 from src.config.database import initialize_database
 from exceptions.handler import base_app_exception_handler
@@ -30,11 +30,6 @@ app.add_middleware(
     allow_headers=["*"],
 )
 app.middleware("http")(jwt_authentication_middleware)
-
-
-@app.get("/", summary="Test API")
-def read_root():
-    return {"message": "Hello World"}
 
 
 # Include routers


### PR DESCRIPTION
### Related Issues

---

> Please specify the related issue number(s), e.g., #1

close #27 

<br><br>

### Description

---

> Briefly describe the changes made in this PR.

- Restrict get_db to handle only SQLAlchemy exceptions

- Add BaseAppException handler in middleware (Because exception raised in middleware can't access the global exception handler managed by FastAPI)


<br><br>

### Checklist

---

- [x] Have you tested it in the local environment?
- [x] Have you cleaned up unnecessary code? (comments, print statements, etc.)
- [x] Have you used commit messages following the convention?

<br><br>

### Screenshots (Optional)

---

<br><br>

### Additional Context (Optional)

---

<br><br>
