### PR TITLE
fix: Include GitHub username when redirecting after GitHub OAuth login

### DIFF
--- a/src/auth/service.py
+++ b/src/auth/service.py
@@ -45,7 +45,9 @@ async def github_callback(
         raise GitHubAccessTokenError()
 
     github_user = await get_github_user_info(github_access_token)
+    print(github_user)
     github_id = github_user["id"]
+    github_name = github_user["login"]
 
     # Check if there is user data in db
     existing_user = find_user_by_github_id(db, github_id)
@@ -74,7 +76,7 @@ async def github_callback(
         await save_token_to_redis(GITHUB_OAUTH_REDIS, github_id, github_access_token)
         access_token = create_access_token(github_id)
 
-        redirect = RedirectResponse(url=f"{FRONTEND_URL}/register")
+        redirect = RedirectResponse(url=f"{FRONTEND_URL}/register/{github_name}")
         redirect.set_cookie(
             key="access_token",
             value=access_token,


### PR DESCRIPTION
### Related Issues

---

> Please specify the related issue number(s), e.g., #1

close #36

<br><br>

### Description

---

> Briefly describe the changes made in this PR.

- Returns GitHub username after GitHub OAuth login
- Now username can be found in url: `http://localhost:5173/register/jhssong`

<br><br>

### Checklist

---

- [x] Have you tested it in the local environment?
- [x] Have you cleaned up unnecessary code? (comments, print statements, etc.)
- [x] Have you used commit messages following the convention?

<br><br>

### Screenshots (Optional)

---

<br><br>

### Additional Context (Optional)

---

<br><br>
