### PR TITLE
hotfix: Remove all files in design_docs not directory itself

### DIFF
--- a/src/config/volume_config.py
+++ b/src/config/volume_config.py
@@ -7,8 +7,10 @@ def clear_design_docs():
     if os.path.exists(base_path):
         for name in os.listdir(base_path):
             path = os.path.join(base_path, name)
-            if os.path.isdir(path):
-                shutil.rmtree(path)
-            else:
-                os.remove(path)
-        shutil.rmtree(base_path)
+            try:
+                if os.path.isdir(path):
+                    shutil.rmtree(path)
+                else:
+                    os.remove(path)
+            except Exception as e:
+                print(f"Failed to delete {path}: {e}")


### PR DESCRIPTION
### Related Issues

---

> Please specify the related issue number(s), e.g., #1

<br><br>

### Description

---

> Briefly describe the changes made in this PR.

If directory was mounted with docker, app cannot remove directory itself
So change the clearing design_docs directory logic to delete only internal files

<br><br>

### Checklist

---

- [x] Have you tested it in the local environment?
- [x] Have you cleaned up unnecessary code? (comments, print statements, etc.)
- [x] Have you used commit messages following the convention?

<br><br>

### Screenshots (Optional)

---

<br><br>

### Additional Context (Optional)

---

<br><br>
