### PR TITLE
fix: Handle streaming response error in generate_issues endpoint

### DIFF
--- a/src/agent/router.py
+++ b/src/agent/router.py
@@ -7,11 +7,11 @@ from src.agent.schemas import (
     AssessStatRes,
     FeedbackReq,
     FeedbackRes,
-    GenerateIssueListRes,
     RecommendAssigneeListRes,
     RecommendAssigneeReq,
 )
 from src.config.database import get_db
+from src.response.error_definitions import IssueGenerateError
 from src.response.schemas import SuccessResponse
 from src.response.success_definitions import (
     assess_success,
@@ -25,19 +25,19 @@ router = APIRouter(prefix="/agent", tags=["Agent"])
 @router.get(
     "/generate_issues/{project_id}",
     summary="Generate issues",
-    response_model=GenerateIssueListRes,
 )
 async def generate_issues(project_id: int, db: Session = Depends(get_db)):
     """
     Generate issues using the agent executor.
     """
-
-    executor = chain.CustomAgentExecutor()
-    return StreamingResponse(
-        executor.generate_issues(project_id, db),
-        media_type="application/json",
-    )
-
+    try:
+        executor = chain.CustomAgentExecutor()
+        return StreamingResponse(
+            executor.generate_issues(project_id, db),
+            media_type="application/json",
+        )
+    except Exception:
+        raise IssueGenerateError()
 
 @router.post(
     "/assess_stat", 


### PR DESCRIPTION
### Related Issues

---

> Please specify the related issue number(s), e.g., #1

<br><br>

close #216 

### Description

---

> Briefly describe the changes made in this PR.

- Remove response_model from generate_issues endpoint
- Add try-catch block for proper exception handling
- Prevent "response already started" error when streaming response

<br><br>

### Checklist

---

- [ ] Have you tested it in the local environment?
- [ ] Have you cleaned up unnecessary code? (comments, print statements, etc.)
- [ ] Have you used commit messages following the convention?

<br><br>

### Screenshots (Optional)

---

<br><br>

### Additional Context (Optional)

---

<br><br>
